### PR TITLE
Fix: Handle EyeDropper user cancel error

### DIFF
--- a/src/eyeDropper.tsx
+++ b/src/eyeDropper.tsx
@@ -40,13 +40,19 @@ export const EyeDropper: FC<PropsWithChildren<EyeDropperProps>> = (props) => {
     return () => document.removeEventListener("keydown", exitPickingByEsc);
   }, [pickingFromDocument, exitPickingByEsc]);
 
-  const onPickStart = useCallback(async () => {
-    const { sRGBHex } = await eyeDropper.open({ signal: abortSignal });
-    const color: Color = {
-      hex: sRGBHex,
-    };
-    onPick(color);
-  }, [eyeDropper, abortSignal, onPick]);
+  const onPickStart = useCallback(() => {
+    eyeDropper
+      .open({ signal: abortSignal })
+      .then(({ sRGBHex }) => {
+          const color: Color = {
+              hex: sRGBHex,
+          };
+          onPick(color);
+      })
+      .catch(() => {
+          onPickCancel();
+      });
+  }, [eyeDropper, abortSignal, onPick, onPickCancel]);
 
   useEffect(() => {
     on && onPickStart();


### PR DESCRIPTION
The `onPickCancel` method wasn't being called when the user canceled the color picker. I've added a catch block to handle the error thrown by the EyeDropper API, which now calls the `onPickCancel` method. This allows the consumer to handle re-rendering the color picker.